### PR TITLE
2600: use .UA extension for Pleiades

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,6 +902,9 @@ These need the `.CV` extension:
 - Magicard
 - Video Life
 
+This needs the `.UA` extension:
+- Pleiades
+
 Other changes:
 
 *Dig Dug* needs to have the first 256 bytes zeroed out (or set to all


### PR DESCRIPTION
Pleiades uses UA bankswitching as documented [here](http://blog.kevtris.org/blogfiles/Atari%202600%20Mappers.txt) and [here](https://github.com/MiSTer-devel/Atari2600_MiSTer) and [here](https://docs.google.com/spreadsheets/d/10fHcUtS7Z4sIaK9OfbgSLm9z_gj8Rw7xbe3AoBiUA74) and [here](https://atariage.com/software_page.php?SoftwareLabelID=821)