### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ described
 
 Unzip [SD Card System
 Structure\_verJB6.6.zip](https://github.com/SmokeMonsterPacks/Nt-Mini-Noir-Jailbreak/raw/main/firmware/SD%20Card%20System%20Structure_verJB6.6.zip)
-into the root directory of your SD card. You will now have a set of
+and move all the content from the unzipped folder into the root directory of your SD card. You will now have a set of
 folders reflecting where game ROMs should be stored. Follow the
 instructions below for configuring the `/BIOS/` folder.
 


### PR DESCRIPTION
The original text was misleading 
<q>Unzip SD Card System Structure_verJB6.6.zip into the root directory of your SD card.</q>
it makes you think you can directly unzip the folder into the root directory, but if you do you'll end up with the "SD.Card.System.Structure_verJ..."
in the root and this will return "Core loading error !" when trying to load any core (except for the NES one).
Many people from Discord and Reddit seem to have come across this issue.
So I updated the instruction to make it more clear.